### PR TITLE
fix mqtt feed url

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ bx wsk rule create publishtoSMS msgTranslated sendSMS
 
 ### 5. Deploy MQTT Feed
 
-Install the MQTT package/feed found in the openwhisk-package-mqtt-watson submodule [here](openwhisk-package-mqtt-watson). This "feed" enables OpenWhisk to subscribe to one or more MQTT topics and invoke actions in response to incoming messages. To see more on how feeds work with IBM Cloud Functions, please visit these [documents](https://github.com/apache/incubator-openwhisk/blob/master/docs/feeds.md)
+Install the MQTT package/feed found in the openwhisk-package-mqtt-watson submodule [here](https://github.com/kkbankol-ibm/openwhisk-package-mqtt-watson/tree/c9938971eab75b0098323fe008c116667193cdb2). This "feed" enables OpenWhisk to subscribe to one or more MQTT topics and invoke actions in response to incoming messages. To see more on how feeds work with IBM Cloud Functions, please visit these [documents](https://github.com/apache/incubator-openwhisk/blob/master/docs/feeds.md)
 
 After the Feed has been deployed send a MQTT message to the topic registered with the feed like so
 ```


### PR DESCRIPTION
correctly link to the `openwhisk-package-mqtt-watson` submodule in
the README

fixes #32